### PR TITLE
Add interactive fixture and standings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Apertura2025LRRF
+# Apertura 2025 LRRF
+
+Este repositorio contiene una página web que muestra el fixture y la tabla de posiciones
+para el torneo Apertura 2025 de la Liga Regional Riotercerense de Fútbol.
+
+Para visualizar la web abra el archivo `index.html` en un navegador web. Los resultados
+de las fechas 1 a la 13 provienen del archivo Excel original y no son editables. Las
+fechas 14, 15 y 16 permiten ingresar los resultados y la tabla se actualiza automáticamente.
+
+El archivo `data.json` se generó a partir del Excel y contiene las fechas y equipos.
+

--- a/data.json
+++ b/data.json
@@ -1,0 +1,1046 @@
+{
+  "tabla": [
+    {
+      "pos": 1,
+      "team": "BELGRANO (BERROTARAN)",
+      "pts": 24,
+      "PJ": 13,
+      "PG": 7,
+      "PE": 3,
+      "PP": 3,
+      "GF": 26,
+      "GC": 18,
+      "DG": 8
+    },
+    {
+      "pos": 2,
+      "team": "ATL. RIO TERCERO",
+      "pts": 24,
+      "PJ": 13,
+      "PG": 7,
+      "PE": 3,
+      "PP": 3,
+      "GF": 20,
+      "GC": 14,
+      "DG": 6
+    },
+    {
+      "pos": 3,
+      "team": "JUVENTUD AGRARIO",
+      "pts": 22,
+      "PJ": 13,
+      "PG": 6,
+      "PE": 4,
+      "PP": 3,
+      "GF": 20,
+      "GC": 16,
+      "DG": 4
+    },
+    {
+      "pos": 4,
+      "team": "TALLERES (BERROTARAN)",
+      "pts": 21,
+      "PJ": 13,
+      "PG": 5,
+      "PE": 6,
+      "PP": 2,
+      "GF": 19,
+      "GC": 12,
+      "DG": 7
+    },
+    {
+      "pos": 5,
+      "team": "REC. ELENENSE",
+      "pts": 20,
+      "PJ": 13,
+      "PG": 6,
+      "PE": 2,
+      "PP": 5,
+      "GF": 19,
+      "GC": 16,
+      "DG": 3
+    },
+    {
+      "pos": 6,
+      "team": "NAUTICO RUMIPAL",
+      "pts": 19,
+      "PJ": 13,
+      "PG": 5,
+      "PE": 4,
+      "PP": 4,
+      "GF": 17,
+      "GC": 18,
+      "DG": -1
+    },
+    {
+      "pos": 7,
+      "team": "9 DE JULIO (RIO TERCERO)",
+      "pts": 18,
+      "PJ": 13,
+      "PG": 5,
+      "PE": 3,
+      "PP": 5,
+      "GF": 18,
+      "GC": 13,
+      "DG": 5
+    },
+    {
+      "pos": 8,
+      "team": "SP. BELGRANO",
+      "pts": 18,
+      "PJ": 13,
+      "PG": 5,
+      "PE": 3,
+      "PP": 5,
+      "GF": 20,
+      "GC": 19,
+      "DG": 1
+    },
+    {
+      "pos": 9,
+      "team": "DEP. INDEPENDIENTE",
+      "pts": 18,
+      "PJ": 13,
+      "PG": 4,
+      "PE": 6,
+      "PP": 3,
+      "GF": 17,
+      "GC": 18,
+      "DG": -1
+    },
+    {
+      "pos": 10,
+      "team": "ATL. ALMAFUERTE",
+      "pts": 17,
+      "PJ": 13,
+      "PG": 5,
+      "PE": 2,
+      "PP": 6,
+      "GF": 21,
+      "GC": 26,
+      "DG": -5
+    },
+    {
+      "pos": 11,
+      "team": "VILLA GENERAL BELGRANO",
+      "pts": 16,
+      "PJ": 13,
+      "PG": 4,
+      "PE": 4,
+      "PP": 5,
+      "GF": 15,
+      "GC": 13,
+      "DG": 2
+    },
+    {
+      "pos": 12,
+      "team": "ATL. ASCASUBI",
+      "pts": 15,
+      "PJ": 13,
+      "PG": 3,
+      "PE": 6,
+      "PP": 4,
+      "GF": 18,
+      "GC": 22,
+      "DG": -4
+    },
+    {
+      "pos": 13,
+      "team": "ATL. INDEPENDIENTE",
+      "pts": 14,
+      "PJ": 13,
+      "PG": 3,
+      "PE": 5,
+      "PP": 5,
+      "GF": 13,
+      "GC": 14,
+      "DG": -1
+    },
+    {
+      "pos": 14,
+      "team": "ESTUDIANTES (HERNANDO)",
+      "pts": 14,
+      "PJ": 13,
+      "PG": 4,
+      "PE": 2,
+      "PP": 7,
+      "GF": 9,
+      "GC": 18,
+      "DG": -9
+    },
+    {
+      "pos": 15,
+      "team": "VECINOS UNIDOS",
+      "pts": 13,
+      "PJ": 13,
+      "PG": 1,
+      "PE": 10,
+      "PP": 2,
+      "GF": 19,
+      "GC": 20,
+      "DG": -1
+    },
+    {
+      "pos": 16,
+      "team": "DEPORTIVO ITALIANO",
+      "pts": 6,
+      "PJ": 13,
+      "PG": 1,
+      "PE": 3,
+      "PP": 9,
+      "GF": 11,
+      "GC": 25,
+      "DG": -14
+    }
+  ],
+  "fechas": [
+    {
+      "fecha": 1,
+      "partidos": [
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 2,
+          "goles_visitante": 1
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 0,
+          "goles_visitante": 3
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 2,
+          "goles_visitante": 3
+        }
+      ]
+    },
+    {
+      "fecha": 2,
+      "partidos": [
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 0,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 1,
+          "goles_visitante": 0
+        }
+      ]
+    },
+    {
+      "fecha": 3,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 3,
+          "goles_visitante": 1
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 3,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 1,
+          "goles_visitante": 2
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 4,
+          "goles_visitante": 3
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": 2,
+          "goles_visitante": 2
+        }
+      ]
+    },
+    {
+      "fecha": 4,
+      "partidos": [
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 2,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 2,
+          "goles_visitante": 1
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 2,
+          "goles_visitante": 3
+        }
+      ]
+    },
+    {
+      "fecha": 5,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 0,
+          "goles_visitante": 3
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 3,
+          "goles_visitante": 2
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 1,
+          "goles_visitante": 2
+        }
+      ]
+    },
+    {
+      "fecha": 6,
+      "partidos": [
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 0,
+          "goles_visitante": 2
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 0,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 0,
+          "goles_visitante": 6
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 0,
+          "goles_visitante": 3
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 3,
+          "goles_visitante": 0
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 1,
+          "goles_visitante": 3
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 1,
+          "goles_visitante": 1
+        }
+      ]
+    },
+    {
+      "fecha": 7,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 1,
+          "goles_visitante": 3
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 3,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 3,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 3,
+          "goles_visitante": 1
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 2,
+          "goles_visitante": 2
+        }
+      ]
+    },
+    {
+      "fecha": 8,
+      "partidos": [
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 4,
+          "goles_visitante": 3
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 3,
+          "goles_visitante": 2
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 3,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 2,
+          "goles_visitante": 1
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 1,
+          "goles_visitante": 3
+        }
+      ]
+    },
+    {
+      "fecha": 9,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 1,
+          "goles_visitante": 3
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 1,
+          "goles_visitante": 3
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 0,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": 1,
+          "goles_visitante": 1
+        }
+      ]
+    },
+    {
+      "fecha": 10,
+      "partidos": [
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 0,
+          "goles_visitante": 2
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 3,
+          "goles_visitante": 0
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 1,
+          "goles_visitante": 2
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 2,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 2,
+          "goles_visitante": 0
+        }
+      ]
+    },
+    {
+      "fecha": 11,
+      "partidos": [
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": 1,
+          "goles_visitante": 2
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": 3,
+          "goles_visitante": 0
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 0,
+          "goles_visitante": 3
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 0,
+          "goles_visitante": 1
+        }
+      ]
+    },
+    {
+      "fecha": 12,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 4,
+          "goles_visitante": 1
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": 2,
+          "goles_visitante": 2
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 4,
+          "goles_visitante": 1
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": 1,
+          "goles_visitante": 0
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 1
+        }
+      ]
+    },
+    {
+      "fecha": 13,
+      "partidos": [
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "SP. BELGRANO",
+          "goles_local": 1,
+          "goles_visitante": 2
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": 2,
+          "goles_visitante": 0
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": 1,
+          "goles_visitante": 2
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": 0,
+          "goles_visitante": 0
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": 1,
+          "goles_visitante": 4
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "REC. ELENENSE",
+          "goles_local": 1,
+          "goles_visitante": 1
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": 5,
+          "goles_visitante": 2
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": 1,
+          "goles_visitante": 2
+        }
+      ]
+    },
+    {
+      "fecha": 14,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "REC. ELENENSE",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "NAUTICO RUMIPAL",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": null,
+          "goles_visitante": null
+        }
+      ]
+    },
+    {
+      "fecha": 15,
+      "partidos": [
+        {
+          "local": "ESTUDIANTES (HERNANDO)",
+          "visitante": "SP. BELGRANO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "9 DE JULIO (RIO TERCERO)",
+          "visitante": "DEP. INDEPENDIENTE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "VILLA GENERAL BELGRANO",
+          "visitante": "ATL. ASCASUBI",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "BELGRANO (BERROTARAN)",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "TALLERES (BERROTARAN)",
+          "visitante": "REC. ELENENSE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "JUVENTUD AGRARIO",
+          "visitante": "DEPORTIVO ITALIANO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "VECINOS UNIDOS",
+          "visitante": "ATL. RIO TERCERO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. ALMAFUERTE",
+          "visitante": "ATL. INDEPENDIENTE",
+          "goles_local": null,
+          "goles_visitante": null
+        }
+      ]
+    },
+    {
+      "fecha": 16,
+      "partidos": [
+        {
+          "local": "SP. BELGRANO",
+          "visitante": "ATL. ALMAFUERTE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. INDEPENDIENTE",
+          "visitante": "VECINOS UNIDOS",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. RIO TERCERO",
+          "visitante": "JUVENTUD AGRARIO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "DEPORTIVO ITALIANO",
+          "visitante": "TALLERES (BERROTARAN)",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "NAUTICO RUMIPAL",
+          "visitante": "REC. ELENENSE",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "BELGRANO (BERROTARAN)",
+          "visitante": "VILLA GENERAL BELGRANO",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "ATL. ASCASUBI",
+          "visitante": "9 DE JULIO (RIO TERCERO)",
+          "goles_local": null,
+          "goles_visitante": null
+        },
+        {
+          "local": "DEP. INDEPENDIENTE",
+          "visitante": "ESTUDIANTES (HERNANDO)",
+          "goles_local": null,
+          "goles_visitante": null
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Fixture Apertura 2025</title>
+<style>
+  body{font-family:sans-serif;margin:20px;}
+  table{border-collapse:collapse;margin-bottom:20px;}
+  th,td{border:1px solid #999;padding:4px 8px;text-align:center;}
+  th{background:#eee;}
+  .fecha{margin-top:20px;}
+</style>
+</head>
+<body>
+<h1>Apertura 2025 LRRF</h1>
+<div id="fechas"></div>
+<h2>Tabla de Posiciones</h2>
+<table id="tabla">
+  <thead>
+    <tr>
+      <th>Pos</th><th>Equipo</th><th>Pts</th><th>PJ</th><th>PG</th><th>PE</th><th>PP</th><th>GF</th><th>GC</th><th>DG</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<script>
+async function cargar(){
+  const resp=await fetch('data.json');
+  const data=await resp.json();
+  const cont=document.getElementById('fechas');
+  data.fechas.forEach(fecha=>{
+    const div=document.createElement('div');
+    div.className='fecha';
+    const h=document.createElement('h2');
+    h.textContent='Fecha '+fecha.fecha;
+    div.appendChild(h);
+    const table=document.createElement('table');
+    const tb=document.createElement('tbody');
+    fecha.partidos.forEach((p,idx)=>{
+      const tr=document.createElement('tr');
+      const tdLocal=document.createElement('td');
+      tdLocal.textContent=p.local;
+      const tdVisit=document.createElement('td');
+      tdVisit.textContent=p.visitante;
+      const tdRes=document.createElement('td');
+      if(fecha.fecha>=14){
+        const inpL=document.createElement('input');
+        inpL.type='number';
+        inpL.min=0;
+        inpL.value=p.goles_local??'';
+        const inpV=document.createElement('input');
+        inpV.type='number';
+        inpV.min=0;
+        inpV.value=p.goles_visitante??'';
+        inpL.addEventListener('input',()=>{p.goles_local=inpL.value!==''?parseInt(inpL.value):null;actualizarTabla();});
+        inpV.addEventListener('input',()=>{p.goles_visitante=inpV.value!==''?parseInt(inpV.value):null;actualizarTabla();});
+        tdRes.appendChild(inpL);
+        tdRes.appendChild(document.createTextNode(' - '));
+        tdRes.appendChild(inpV);
+      } else {
+        tdRes.textContent=p.goles_local+' - '+p.goles_visitante;
+      }
+      tr.appendChild(tdLocal);
+      tr.appendChild(tdRes);
+      tr.appendChild(tdVisit);
+      tb.appendChild(tr);
+    });
+    table.appendChild(tb);
+    div.appendChild(table);
+    cont.appendChild(div);
+  });
+  window.data=data;
+  actualizarTabla();
+}
+
+function actualizarTabla(){
+  const tabla=computeTabla(window.data.fechas);
+  const tbody=document.querySelector('#tabla tbody');
+  tbody.innerHTML='';
+  tabla.forEach(t=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${t.pos}</td><td>${t.team}</td><td>${t.pts}</td><td>${t.PJ}</td><td>${t.PG}</td><td>${t.PE}</td><td>${t.PP}</td><td>${t.GF}</td><td>${t.GC}</td><td>${t.DG}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function computeTabla(fechas){
+  const stats={};
+  fechas.forEach(f=>{
+    f.partidos.forEach(p=>{
+      stats[p.local]=stats[p.local]||{team:p.local,pts:0,PJ:0,PG:0,PE:0,PP:0,GF:0,GC:0};
+      stats[p.visitante]=stats[p.visitante]||{team:p.visitante,pts:0,PJ:0,PG:0,PE:0,PP:0,GF:0,GC:0};
+      if(p.goles_local==null||p.goles_visitante==null) return;
+      const L=stats[p.local], V=stats[p.visitante];
+      L.PJ++; V.PJ++;
+      L.GF+=p.goles_local; L.GC+=p.goles_visitante;
+      V.GF+=p.goles_visitante; V.GC+=p.goles_local;
+      if(p.goles_local>p.goles_visitante){L.PG++; L.pts+=3; V.PP++;}
+      else if(p.goles_local<p.goles_visitante){V.PG++; V.pts+=3; L.PP++;}
+      else{L.PE++; V.PE++; L.pts++; V.pts++;}
+    });
+  });
+  const arr=Object.values(stats).map(s=>{s.DG=s.GF-s.GC;return s;});
+  arr.sort((a,b)=>b.pts-a.pts||b.DG-a.DG||b.GF-a.GF||a.team.localeCompare(b.team));
+  arr.forEach((s,i)=>s.pos=i+1);
+  return arr;
+}
+
+cargar();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- parse Excel data into JSON
- create a simple HTML page to display fixtures
- allow editing of rounds 14-16 and update standings dynamically
- document how to view the page

## Testing
- `python3 - <<'PY' ...` (parses Excel to JSON)


------
https://chatgpt.com/codex/tasks/task_e_68486ff0aa64833181004563a1abfb08